### PR TITLE
Add support for Denarius

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,19 @@
 
 ccgen is a simple(ish) semi-universal address and vanity address generator for cryptocurrency.
 
-*Currently supports Bitcoin, Paycoin and LiteDoge. Pull requests for coin support are welcome.*
+## Supported Coins
+
+Current List of Available Coins for Address Generation  
+-----
+|**Coin Short** | **Coin Name** | **Address Prefix**  |
+| --------------------------------------- | -------------------------------------------- | ------------ |
+|BTC | Bitcoin | 1  |
+|DNR | Denarius | D  |
+|LDOGE | LiteDoge | d  |
+|LTC | Litecoin | L  |
+|XPY | Paycoin | P  |
+
+*Pull requests for coin support are welcome.*
 
 ## Usage
 

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -30,6 +30,9 @@ func GenerateAddress(ctype string, compress bool) (string, string, error) {
 	case strings.ToLower(ctype) == "paycoin" || strings.ToLower(ctype) == "xpy":
 		p = &params.PaycoinParams
 		break
+	case strings.ToLower(ctype) == "denarius" || strings.ToLower(ctype) == "dnr":
+		p = &params.DenariusParams
+		break
 	default:
 		p = &chaincfg.MainNetParams
 		break

--- a/params/denarius.go
+++ b/params/denarius.go
@@ -1,0 +1,11 @@
+package params
+
+import "github.com/btcsuite/btcd/chaincfg"
+
+// DenariusParams defines the chopped down Denarius parameters.
+var DenariusParams = chaincfg.Params{
+	Name: "denarius",
+
+	PubKeyHashAddrID: 0x1E, // starts with D
+	PrivateKeyID:     0x9E, // starts with 6 (uncompressed) or Q (compressed)
+}


### PR DESCRIPTION
This commit adds support for Denarius (DNR) address generation.

More information on Denarius can be found here: https://denarius.io/
